### PR TITLE
Flycheck: parse warnings

### DIFF
--- a/solidity-mode.el
+++ b/solidity-mode.el
@@ -438,7 +438,7 @@ Highlight the 1st result."
     :command ("/usr/bin/solc" source-inplace)
     :error-patterns
     ((error line-start (file-name) ":" line ":" column ":" " Error: " (message))
-     (warning line-start "Error: " (message)))
+     (error line-start "Error: " (message)))
     :modes solidity-mode
     :predicate (lambda () (eq major-mode 'solidity-mode)))
   (add-to-list 'flycheck-checkers 'solidity-checker)

--- a/solidity-mode.el
+++ b/solidity-mode.el
@@ -438,7 +438,8 @@ Highlight the 1st result."
     :command ("/usr/bin/solc" source-inplace)
     :error-patterns
     ((error line-start (file-name) ":" line ":" column ":" " Error: " (message))
-     (error line-start "Error: " (message)))
+     (error line-start "Error: " (message))
+     (warning line-start (file-name) ":" line ":" column ":" " Warning: " (message)))
     :modes solidity-mode
     :predicate (lambda () (eq major-mode 'solidity-mode)))
   (add-to-list 'flycheck-checkers 'solidity-checker)


### PR DESCRIPTION
To support parsing of compiler warnings like:

`hello.sol:1:1: Warning: Source file does not specify required compiler version!Consider adding "pragma solidity ^0.4.13
`

Thanks for this mode! :+1: 