### PR TITLE
Fix Using Solc and Flycheck for recent Flycheck Versions

### DIFF
--- a/solidity-mode.el
+++ b/solidity-mode.el
@@ -49,12 +49,6 @@
   :type 'string
   :package-version '(solidity . "0.1.1"))
 
-(defcustom solidity-solc-extra-args ""
-  "Extra arguments to add to pass to the solidity compiler."
-  :group 'solidity
-  :type 'string
-  :package-version '(solidity . "0.1.2"))
-
 (defvar solidity-mode-map
   (let ((map (make-keymap)))
     (define-key map "\C-j" 'newline-and-indent)
@@ -63,7 +57,6 @@
 
 (defvar solidity-checker t "The solidity flycheck syntax checker.")
 (defvar solidity-mode t "The solidity major mode.")
-(defvar flycheck-solidity-executable t "The solc executable used by flycheck.")
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.sol\\'" . solidity-mode))
@@ -451,13 +444,24 @@ Highlight the 1st result."
 
 ;;; --- interface with flycheck if existing ---
 (when (eval-when-compile (require 'flycheck nil 'noerror))
+  (flycheck-def-option-var flycheck-solidity-addstd-contracts nil solidity-checker
+    "Whether to add standard solidity contracts.
+
+When non-nil, enable add also standard solidity contracts via
+`--add-std'."
+    :type 'boolean
+    :safe #'booleanp
+    :package-version '(solidity-mode . "0.1.3"))
+
   ;; add dummy source-inplace definition to avoid errors
   (defvar source-inplace t)
   ;; add a solidity mode callback to set the executable of solc for flycheck
   ;; define solidity's flycheck syntax checker
   (flycheck-define-checker solidity-checker
     "A Solidity syntax checker using the solc compiler"
-    :command ("/usr/bin/solc" source-inplace)
+    :command ("solc"
+              (option-flag "--add-std" flycheck-solidity-addstd-contracts)
+              source-inplace)
     :error-patterns
     ((error line-start (file-name) ":" line ":" column ":" " Error: " (message))
      (error line-start "Error: " (message))

--- a/solidity-mode.el
+++ b/solidity-mode.el
@@ -467,7 +467,7 @@ Highlight the 1st result."
   (add-to-list 'flycheck-checkers 'solidity-checker)
   (add-hook 'solidity-mode-hook
             (lambda ()
-              (let ((solidity-command (concat solidity-solc-path " " solidity-solc-extra-args)))
+              (let ((solidity-command (concat solidity-solc-path)))
                 (setq flycheck-solidity-checker-executable solidity-command)))))
 
 (provide 'solidity-mode)

--- a/solidity-mode.el
+++ b/solidity-mode.el
@@ -1,10 +1,10 @@
 ;;; solidity-mode.el --- Major mode for ethereum's solidity language
 
-;; Copyright (C) 2015  Lefteris Karapetsas
+;; Copyright (C) 2015-2018  Lefteris Karapetsas
 
 ;; Author: Lefteris Karapetsas  <lefteris@refu.co>
 ;; Keywords: languages
-;; Version: 0.1.2
+;; Version: 0.1.3
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -444,6 +444,9 @@ Highlight the 1st result."
 
 ;;; --- interface with flycheck if existing ---
 (when (eval-when-compile (require 'flycheck nil 'noerror))
+  ;; Avoid reference to free variable warnings
+  (defvar flycheck-solidity-checker-executable)
+
   (flycheck-def-option-var flycheck-solidity-addstd-contracts nil solidity-checker
     "Whether to add standard solidity contracts.
 


### PR DESCRIPTION
Fix #15 
The problem was that 

```elisp
(let ((solidity-command (concat solidity-solc-path " " solidity-solc-extra-args)))
               (let ((solidity-command (concat solidity-solc-path)))
                 (setq flycheck-solidity-checker-executable solidity-command)))))
```
would lead to the `flycheck-solidity-checker-executable` having extra args or a trailing space. That worked fine for earlier flycheck versions but in latest flycheck the executable needs to be just the simple path to the executable without any args or even a trailing space.