### PR TITLE
Option to customize comment style

### DIFF
--- a/README.org
+++ b/README.org
@@ -30,6 +30,15 @@ Regardless of where you installed solidity mode from, you need to require the pa
 #+END_SRC
 (append that line to your =~/.emacs= file)
 
+You can also set the way the comments are inserted by emacs with commands like =comment-region=. The default is 
+=/* .. */= and you can turn it to using =//= instead by putting the following into your emacs config:
+
+#+BEGIN_SRC lisp
+(setq solidity-comment-style 'slash)
+;; or
+(setq solidity-comment-style 'star) ;; this is the default
+#+END_SRC
+
 ** Keymap
 You can modify the default keybindings of the solidity mode keymap by adding
 a new key combination for each command you want to change. For example

--- a/changelog.MD
+++ b/changelog.MD
@@ -2,6 +2,16 @@
 
 The changelog starts from version 0.1.4 as too much was added in each version before that.
 
+## Version 0.1.7
+
+- Allow for customization of the way that emacs inserts comments into the source file via
+
+```emacs-lisp
+(setq solidity-comment-style 'slash)
+;; or
+(setq solidity-comment-style 'star) ;; this is the default
+```
+
 ## Version 0.1.6
 
 - Add gas estimation code. User facing function is `solidity-estimate-gas-at-point`.

--- a/solidity-mode.el
+++ b/solidity-mode.el
@@ -4,7 +4,7 @@
 
 ;; Author: Lefteris Karapetsas  <lefteris@refu.co>
 ;; Keywords: languages
-;; Version: 0.1.6
+;; Version: 0.1.7
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -95,6 +95,25 @@ Possible values are:
                  (const :tag "Chain after error-error level" error)
                  (const :tag "Always chain" t))
   :package-version '(solidity . "0.1.5")
+  :safe #'symbolp)
+
+(defcustom solidity-comment-style 'star
+  "Denotes the style of comments to use for solidity when commenting.
+
+This option will define what kind of comments will be input into the buffer by
+commands like `comment-region'.  The default value is 'star.
+Possible values are:
+
+`star'
+    Follow the same styling as C mode does by default having all comments
+    obey the /* .. */ style.
+
+`slash'
+    All comments will start with //."
+  :group 'solidity
+  :type '(choice (const :tag "Commenting starts with /* and ends with */" star)
+                 (const :tag "Commenting starts with //" slash))
+  :package-version '(solidity . "0.1.7")
   :safe #'symbolp)
 
 (defvar solidity-mode-map
@@ -529,9 +548,13 @@ Cursor must be at the function's name.  Does not currently work for constructors
   (set-syntax-table solidity-mode-syntax-table)
   ;; specify syntax highlighting
   (setq font-lock-defaults '(solidity-font-lock-keywords))
-  ;; register indentation functions, basically the c-mode ones
-  (make-local-variable 'comment-start)
-  (make-local-variable 'comment-end)
+
+  ;; register indentation and other langue mode functions, basically the c-mode ones with some modifications
+  (let ((start-value (if (eq solidity-comment-style 'star) "/* " "// "))
+        (end-value (if (eq solidity-comment-style 'star) " */" "")))
+    (set (make-local-variable 'comment-start) start-value)
+    (set (make-local-variable 'comment-end) end-value))
+
   (make-local-variable 'comment-start-skip)
 
   (make-local-variable 'paragraph-start)
@@ -541,7 +564,7 @@ Cursor must be at the function's name.  Does not currently work for constructors
   (make-local-variable 'adaptive-fill-regexp)
   (make-local-variable 'fill-paragraph-handle-comment)
 
-  ;; now set their values
+  ;; set values for some other variables
   (set (make-local-variable 'parse-sexp-ignore-comments) t)
   (set (make-local-variable 'indent-line-function) 'c-indent-line)
   (set (make-local-variable 'indent-region-function) 'c-indent-region)


### PR DESCRIPTION
User can now customize comment style

Default is `/* .. */`

Customize through

```emacs-lisp
(setq solidity-comment-style 'slash)
;; or
(setq solidity-comment-style 'star)
```