### PR TITLE
Add emit keyword

### DIFF
--- a/solidity-mode.el
+++ b/solidity-mode.el
@@ -94,6 +94,7 @@ Possible values are:
     "delete"
     "do"
     "else"
+    "emit"
     "event"
     "external"
     "for"


### PR DESCRIPTION
Highlight `emit` keyword in statements like `emit Event(x);`.