### PR TITLE
Added autocompletion section to readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -130,3 +130,6 @@ if possible, for the function.
 + Indentation
 + On the fly syntax checking with flycheck
 + Gas estimation for function under point
+
+* Autocompletion
+For autocompletion, you can install [[https://github.com/ssmolkin1/company-solidity][company-solidity]], a [[http://company-mode.github.io/][company-mode]] back-end for Solidity. 


### PR DESCRIPTION
Hi, I'm the author of [company-solidity](https://github.com/ssmolkin1/company-solidity), a simple autocompletion back-end for `company-mode`. It's fairly new, but it looks like a number of folks are [already using it](https://melpa.org/#/?q=company-solidity). Together with `solidity-mode`, I think this makes emacs the best text editor for Solidity!  So, I've added a section to the end of the README pointing folks to `company-solidity` for autocompletion.