### PR TITLE
Integrated company-solidity for autocompletion

### DIFF
--- a/README.org
+++ b/README.org
@@ -117,6 +117,29 @@ how they are chained. Its value can be either =t=, =error=, =warning= or =info= 
 of the solc checker after which solium will not run. If =t= is given solium will always run. The default is =warning=, so
 if anything over than a warning is found in solc solium will not run.
 
+** [Optional] Autocompletion
+[[https://github.com/ssmolkin1/company-solidity][company-solidity]], a simple [[http://company-mode.github.io/][company-mode]] back-end for Solidity, has now been fully integrated into solidity-mode. You no longer need to install company-solidity separately from solidity-mode, nor should you do so. To take advantage of the autocompletion features, you must have the [[http://company-mode.github.io/][company-mode]] package installed. The autocompletion features will be enabled automatically if you have company-mode installed.
+
+*** What it does
+Give completion suggestions for Solidity keywords, global variables, and address methods.
+
+*** What it isn't
+Smart. The completion suggestions are *not context dependent*.
+
+*** Something to watch out for
+=company-mode= treats =.= as the end of a word, and will cut off compeletion suggestions when you type a =.=. So, when you've typed =msg= you will get =msg.sender=, =msg.value= etc. as completion suggestions. However, as soon as you type =msg.=, the suggestions will disappear.
+
+*** Local Variables
+If you want autocomplete suggestions to include local variables, in addition to Solidity keywords, add the following to your =init.el=:
+
+#+BEGIN_SRC emacs-lisp
+(add-hook 'solidity-mode-hook
+	(lambda ()
+	(set (make-local-variable 'company-backends)
+		(append '((company-solidity company-capf company-dabbrev-code))
+			company-backends))))
+#+END_SRC
+
 * Commands
 
 ** Gas estimate of function under point
@@ -127,9 +150,7 @@ This will call =solidity-estimate-gas-at-point= and provide a max gas estimate,
 if possible, for the function.
 * Features
 + Syntax highlighting
++ Autocompletion
 + Indentation
 + On the fly syntax checking with flycheck
 + Gas estimation for function under point
-
-* Autocompletion
-For autocompletion, you can install [[https://github.com/ssmolkin1/company-solidity][company-solidity]], a [[http://company-mode.github.io/][company-mode]] back-end for Solidity. 

--- a/changelog.MD
+++ b/changelog.MD
@@ -2,6 +2,10 @@
 
 The changelog starts from version 0.1.4 as too much was added in each version before that.
 
+## Version 0.1.9
+
+- Integrated [company-solidity](https://github.com/ssmolkin1/company-solidity) into solidity-mode, providing autocompletion out of the box if the user has [company-mode](http://company-mode.github.io) installed.
+
 ## Version 0.1.8
 
 - Bugfix for [issue 8](https://github.com/ethereum/emacs-solidity/issues/8). Now if flycheck is not installed

--- a/company-solidity.el
+++ b/company-solidity.el
@@ -1,0 +1,136 @@
+;;; company-solidity.el --- Company-mode back-end for solidity-mode
+
+;; Copyright (C) 2018  Samuel Smolkin
+
+;; Author: Samuel Smolkin <sam@future-precedent.org>
+;; URL: https://github.com/ethereum/emacs-solidity
+;; Keywords: solidity, completion, company
+;; Version: 2.0.0
+;; Package-Requires: ((company "0.9.0") (cl-lib "0.5.0"))
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This package provides a simple company-mode back-end for auto-completing Solidity keywords when working in solidity-mode.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'company)
+
+;; Additional completion targets whcih are nore part of solidty-mode syntax-highlighting keywords lists:
+
+(defconst company-solidity-additional-math
+  '("addmod"
+    "mulmod"))
+
+(defconst company-solidity-additional-hashing
+  '("keccak256"
+    "sha256"
+    "sha3"
+    "ripemd160"
+    "ecrecover"))
+
+(defconst company-solidity-additional-block-methods
+  '("block.blockhash"
+    "block.coinbase"
+    "block.difficulty"
+    "block.gaslimit"
+    "block.number"
+    "block.timestamp"
+    "now"))
+
+(defconst company-solidity-additional-msg-methods
+  '("msg.data"
+    "msg.gas"
+    "msg.sender"
+    "msg.sig"
+    "msg.value"
+    "gasleft"))
+
+(defconst company-solidity-additional-tx-methods
+  '("tx.gasprice"
+    "tx.origin"))
+
+(defconst company-solidity-additional-address-methods
+  '("balance"
+    "transfer"
+    "send"
+    "call"
+    "callcode"
+    "delegatecall"))
+
+(defconst company-solidity-additional-contracts
+  '("super"
+    "selfdistruct"
+    "suicide"))
+
+(defconst company-solidity-additional-modifiers
+  '("payable"))
+
+(defconst company-solidity-additional-pragma
+  '("solidity"))
+
+(defconst company-solidity-additional-types
+  '("fixed"
+    "ufixed"
+    "hex"))
+
+(defconst company-solidity-additional-function-methods
+  '("selector"))
+
+;; Completion targets taken from solidity-mode syntax-highlighting keywords lists, plus additional targets above.
+
+(defconst company-solidity-keywords
+  (append
+   solidity-keywords
+   solidity-constants
+   solidity-variable-modifier
+   solidity-builtin-types
+   solidity-builtin-constructs
+   company-solidity-additional-math
+   company-solidity-additional-hashing
+   company-solidity-additional-block-methods
+   company-solidity-additional-msg-methods
+   company-solidity-additional-tx-methods
+   company-solidity-additional-address-methods
+   company-solidity-additional-contracts
+   company-solidity-additional-modifiers
+   company-solidity-additional-pragma
+   company-solidity-additional-types
+   company-solidity-additional-function-methods))
+
+;;;###autoload
+(defun company-solidity (command &optional arg &rest ignored)
+  "Autocompletion for solidity with company mode.
+Argument COMMAND `company-backend` functions.
+Optional argument ARG the completion target prefix.
+Optional argument IGNORED Additional arguments are ingnored."
+    (interactive (list 'interactive))
+    (set (make-local-variable 'company-minimum-prefix-length) 2)
+    (cl-case command
+	(interactive (company-begin-backend 'company-solidity))
+	(prefix (and (eq major-mode 'solidity-mode)
+		    (company-grab-symbol)))
+    (candidates
+    (cl-remove-if-not
+	(lambda (c) (string-prefix-p arg c))
+	company-solidity-keywords))))
+
+(add-to-list 'company-backends 'company-solidity)
+
+(provide 'company-solidity)
+
+;;; company-solidity.el ends here

--- a/company-solidity.el
+++ b/company-solidity.el
@@ -91,8 +91,14 @@
 (defconst company-solidity-additional-function-methods
   '("selector"))
 
-;; Completion targets taken from solidity-mode syntax-highlighting keywords lists, plus additional targets above.
+;; defvar symbols taken from solidity-mode.el to avoid reference warnings
+(defvar solidity-keywords)
+(defvar solidity-constants)
+(defvar solidity-variable-modifier)
+(defvar solidity-builtin-types)
+(defvar solidity-builtin-constructs)
 
+;; Completion targets taken from solidity-mode syntax-highlighting keywords lists, plus additional targets above.
 (defconst company-solidity-keywords
   (append
    solidity-keywords

--- a/company-solidity.el
+++ b/company-solidity.el
@@ -74,7 +74,7 @@
 
 (defconst company-solidity-additional-contracts
   '("super"
-    "selfdistruct"
+    "selfdestruct"
     "suicide"))
 
 (defconst company-solidity-additional-modifiers

--- a/company-solidity.el
+++ b/company-solidity.el
@@ -115,6 +115,7 @@
 ;;;###autoload
 (defun company-solidity (command &optional arg &rest ignored)
   "Autocompletion for solidity with company mode.
+
 Argument COMMAND `company-backend` functions.
 Optional argument ARG the completion target prefix.
 Optional argument IGNORED Additional arguments are ingnored."

--- a/solidity-mode.el
+++ b/solidity-mode.el
@@ -4,7 +4,7 @@
 
 ;; Author: Lefteris Karapetsas  <lefteris@refu.co>
 ;; Keywords: languages
-;; Version: 0.1.8
+;; Version: 0.1.9
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -529,6 +529,10 @@ Cursor must be at the function's name.  Does not currently work for constructors
 ;;; --- interface with flycheck if existing ---
 (when (require 'flycheck nil 'noerror)
   (require 'solidity-flycheck))
+
+;;; --- autcompletion back-end for company-mode, loads if company mode is installed ---
+(when (require 'company nil 'noerror)
+  (require 'company-solidity))
 
 (provide 'solidity-mode)
 ;;; solidity-mode.el ends here


### PR DESCRIPTION
As discussed, [here](https://github.com/ethereum/emacs-solidity/pull/25), I've fully integrated [company-solidity](https://github.com/ssmolkin1/company-solidity) into `solidity-mode`. Similar to what is done for the `solidity-flycheck`, `company-solidity` will automatically be required by `solidity-mode` if `company-mode` is installed.

The list of autocompletion targets is now pulled from the `solidity-mode` keywords lists for syntax highlighting, as well as a number of additional keywords that aren't present there. I had a good look through the official documentation as I prepared this, so hopefully the list is complete (for now).

Some of these additional keywords should probably be syntax-highlighted as well, so should be copied over to the relevant `solidity-mode` keyword lists (at which point they can be deleted from the extra `company-solidity` keywords lists). I've tried to organize the additional keywords in a sensible way to make this process easier.