### PR TITLE
fixes flycheck integration

### DIFF
--- a/README.org
+++ b/README.org
@@ -83,10 +83,6 @@ To activate =solium= checker
 (setq solidity-flycheck-solium-checker-active t)
 #+END_SRC
 
-To enable flycheck integration
-#+BEGIN_SRC emacs-lisp
-(solidity-flycheck-setup)
-#+END_SRC
 
 Keep in mind that you need to provide the path to either solc or solium unless
 emacs can already find it in your environment's =PATH=. Even if you can call it

--- a/README.org
+++ b/README.org
@@ -83,6 +83,10 @@ To activate =solium= checker
 (setq solidity-flycheck-solium-checker-active t)
 #+END_SRC
 
+To enable flycheck integration
+#+BEGIN_SRC emacs-lisp
+(solidity-flycheck-setup)
+#+END_SRC
 
 Keep in mind that you need to provide the path to either solc or solium unless
 emacs can already find it in your environment's =PATH=. Even if you can call it

--- a/changelog.MD
+++ b/changelog.MD
@@ -6,6 +6,8 @@ The changelog starts from version 0.1.4 as too much was added in each version be
 
 - Added the interface keyword (https://github.com/ethereum/emacs-solidity/pull/27).
 
+- Fixed flycheck integration doesn't search for solc and solium in PATH.
+
 ## Version 0.1.9
 
 - Integrated [company-solidity](https://github.com/ssmolkin1/company-solidity) into solidity-mode, providing autocompletion out of the box if the user has [company-mode](http://company-mode.github.io) installed.

--- a/solidity-flycheck.el
+++ b/solidity-flycheck.el
@@ -158,24 +158,25 @@ we pass the directory to solium via the `--config' option."
 			 :modes solidity-mode
 			 :predicate (lambda () (eq major-mode 'solidity-mode)))
 
-;; first try to add solium to the checker's list since if we got solc
-;; it must come after it in the list due to it being chained after solc
-(when solidity-flycheck-solium-checker-active
-  (if (file-executable-p solidity-solium-path)
-      (progn
-	(add-to-list 'flycheck-checkers 'solium-checker)
-	(setq flycheck-solium-checker-executable solidity-solium-path))
-    (error (format "Solidity Mode Configuration error. Requested solium flycheck integration but can't find solium at: %s" solidity-solium-path))))
+;;;###autoload
+(defun solidity-flycheck-setup ()
+  "Setup Solidity support for Flycheck.
+Add `solidity' and `solium' to `flycheck-checkers'."
+  ;; first try to add solium to the checker's list since if we got solc
+  ;; it must come after it in the list due to it being chained after solc
+  (when solidity-flycheck-solium-checker-active
+    (if (funcall flycheck-executable-find solidity-solium-path)
+	(progn
+	  (add-to-list 'flycheck-checkers 'solium-checker)
+	  (setq flycheck-solium-checker-executable solidity-solium-path))
+      (error (format "Solidity Mode Configuration error. Requested solium flycheck integration but can't find solium at: %s" solidity-solium-path))))
 
-(when solidity-flycheck-solc-checker-active
-  (if (file-executable-p solidity-solc-path)
-      (progn
-	(add-to-list 'flycheck-checkers 'solidity-checker)
-	(add-hook 'solidity-mode-hook
-		  (lambda ()
-		    (let ((solidity-command (concat solidity-solc-path)))
-		      (setq flycheck-solidity-checker-executable solidity-command)))))
-    (error (format "Solidity Mode Configuration error. Requested solc flycheck integration but can't find solc at: %s" solidity-solc-path))))
+  (when solidity-flycheck-solc-checker-active
+    (if (funcall flycheck-executable-find solidity-solc-path)
+	(progn
+	  (add-to-list 'flycheck-checkers 'solidity-checker)
+	  (setq flycheck-solidity-checker-executable solidity-solc-path))
+      (error (format "Solidity Mode Configuration error. Requested solc flycheck integration but can't find solc at: %s" solidity-solc-path)))))
 
 (provide 'solidity-flycheck)
 ;;; solidity-flycheck.el ends here

--- a/solidity-flycheck.el
+++ b/solidity-flycheck.el
@@ -158,25 +158,21 @@ we pass the directory to solium via the `--config' option."
 			 :modes solidity-mode
 			 :predicate (lambda () (eq major-mode 'solidity-mode)))
 
-;;;###autoload
-(defun solidity-flycheck-setup ()
-  "Setup Solidity support for Flycheck.
-Add `solidity' and `solium' to `flycheck-checkers'."
-  ;; first try to add solium to the checker's list since if we got solc
-  ;; it must come after it in the list due to it being chained after solc
-  (when solidity-flycheck-solium-checker-active
-    (if (funcall flycheck-executable-find solidity-solium-path)
-	(progn
-	  (add-to-list 'flycheck-checkers 'solium-checker)
-	  (setq flycheck-solium-checker-executable solidity-solium-path))
-      (error (format "Solidity Mode Configuration error. Requested solium flycheck integration but can't find solium at: %s" solidity-solium-path))))
+;; first try to add solium to the checker's list since if we got solc
+;; it must come after it in the list due to it being chained after solc
+(when solidity-flycheck-solium-checker-active
+  (if (funcall flycheck-executable-find solidity-solium-path)
+      (progn
+	(add-to-list 'flycheck-checkers 'solium-checker)
+	(setq flycheck-solium-checker-executable solidity-solium-path))
+    (error (format "Solidity Mode Configuration error. Requested solium flycheck integration but can't find solium at: %s" solidity-solium-path))))
 
-  (when solidity-flycheck-solc-checker-active
-    (if (funcall flycheck-executable-find solidity-solc-path)
-	(progn
-	  (add-to-list 'flycheck-checkers 'solidity-checker)
-	  (setq flycheck-solidity-checker-executable solidity-solc-path))
-      (error (format "Solidity Mode Configuration error. Requested solc flycheck integration but can't find solc at: %s" solidity-solc-path)))))
+(when solidity-flycheck-solc-checker-active
+  (if (funcall flycheck-executable-find solidity-solc-path)
+      (progn
+	(add-to-list 'flycheck-checkers 'solidity-checker)
+	(setq flycheck-solidity-checker-executable solidity-solc-path))
+    (error (format "Solidity Mode Configuration error. Requested solc flycheck integration but can't find solc at: %s" solidity-solc-path))))
 
 (provide 'solidity-flycheck)
 ;;; solidity-flycheck.el ends here


### PR DESCRIPTION
- By default value of `solidity-solc-path` is "solc", therefore
  `(file-executable-p solidity-solium-path)` always return `nil`
  unless `solidity-solium-path` is set to absolute path. This is fixed
  by replace `file-executable-p` with `flycheck-executable-find`.

- The flycheck checkers configurations codes are not loaded when
  `(require solidity-mode)`, moved them to a function to explicitly
  call in config.