### PR TITLE
Conditionally add flag to solium invocation & tweak output parsing for newer solium

### DIFF
--- a/solidity-flycheck.el
+++ b/solidity-flycheck.el
@@ -86,28 +86,28 @@ we pass the directory to solium via the `--config' option."
 
 (when solidity-flycheck-solium-checker-active
   ;; define solium flycheck syntax checker
-  (flycheck-define-checker solium-checker
-                           "A Solidity linter using solium"
-                           :command ("solium"
-                                     (option "--config=" flycheck-solidity-solium-soliumrcfile concat)
-                                     "-f"
-                                     source-inplace)
-                           :error-patterns ((error line-start (zero-or-more " ") line ":" column (zero-or-more " ") "error" (message))
-                                            (error line-start (zero-or-more not-newline) "[Fatal error]" (message))
-                                            (warning line-start (zero-or-more " ") line ":" column (zero-or-more " ") "warning" (message)))
-                           :error-filter
-                           ;; Add fake line numbers if they are missing in the lint output
-                           (lambda (errors)
-                             (dolist (err errors)
-                               (unless (flycheck-error-line err)
-                                 (setf (flycheck-error-line err) 1)))
-                             errors)
-                           :modes solidity-mode
-                           :predicate (lambda () (eq major-mode 'solidity-mode)))
   ;; first try to add solium to the checker's list since if we got solc
   ;; it must come after it in the list due to it being chained after solc
   (if (funcall flycheck-executable-find solidity-solium-path)
       (progn
+        (flycheck-define-checker solium-checker
+          "A Solidity linter using solium"
+          :command ("solium"
+                    (option "--config=" flycheck-solidity-solium-soliumrcfile concat)
+                    "-f"
+                    source-inplace)
+          :error-patterns ((error line-start (zero-or-more " ") line ":" column (zero-or-more " ") "error" (message))
+                           (error line-start (zero-or-more not-newline) "[Fatal error]" (message))
+                           (warning line-start (zero-or-more " ") line ":" column (zero-or-more " ") "warning" (message)))
+          :error-filter
+          ;; Add fake line numbers if they are missing in the lint output
+          (lambda (errors)
+            (dolist (err errors)
+              (unless (flycheck-error-line err)
+                (setf (flycheck-error-line err) 1)))
+            errors)
+          :modes solidity-mode
+          :predicate (lambda () (eq major-mode 'solidity-mode)))
         (add-to-list 'flycheck-checkers 'solium-checker)
         (setq flycheck-solium-checker-executable solidity-solium-path))
     (error (format "Solidity Mode Configuration error. Requested solium flycheck integration but can't find solium at: %s" solidity-solium-path))))
@@ -118,19 +118,19 @@ we pass the directory to solium via the `--config' option."
   ;; expanded the flycheck-define-checker macro in order to eval certain args, as per advice given in gitter
   ;; https://gitter.im/flycheck/flycheck?at=5a43b3a8232e79134d98872b
   (flycheck-def-executable-var solidity-checker "solc")
-  (flycheck-define-command-checker 'solidity-checker
-                                   "A Solidity syntax checker using the solc compiler"
-                                   :command '("solc" source-inplace)
-                                   :error-patterns '((error line-start (file-name) ":" line ":" column ":" " Error: " (message))
-                                                     (error line-start "Error: " (message))
-                                                     (warning line-start (file-name) ":" line ":" column ":" " Warning: " (message)))
-                                   :modes 'solidity-mode
-                                   :predicate #'(lambda nil (eq major-mode 'solidity-mode))
-                                   :next-checkers `((,solidity-flycheck-chaining-error-level . solium-checker))
-                                   :standard-input 'nil
-                                   :working-directory 'nil)
   (if (funcall flycheck-executable-find solidity-solc-path)
       (progn
+        (flycheck-define-command-checker 'solidity-checker
+          "A Solidity syntax checker using the solc compiler"
+          :command '("solc" source-inplace)
+          :error-patterns '((error line-start (file-name) ":" line ":" column ":" " Error: " (message))
+                            (error line-start "Error: " (message))
+                            (warning line-start (file-name) ":" line ":" column ":" " Warning: " (message)))
+          :modes 'solidity-mode
+          :predicate #'(lambda nil (eq major-mode 'solidity-mode))
+          :next-checkers `((,solidity-flycheck-chaining-error-level . solium-checker))
+          :standard-input 'nil
+          :working-directory 'nil)
         (add-to-list 'flycheck-checkers 'solidity-checker)
         (setq flycheck-solidity-checker-executable solidity-solc-path))
     (error (format "Solidity Mode Configuration error. Requested solc flycheck integration but can't find solc at: %s" solidity-solc-path))))

--- a/solidity-flycheck.el
+++ b/solidity-flycheck.el
@@ -84,23 +84,6 @@ we pass the directory to solium via the `--config' option."
                          :safe #'stringp
                          :package-version '(solidity-mode . "0.1.4"))
 
-;; add a solidity mode callback to set the executable of solc for flycheck
-;; define solidity's flycheck syntax checker
-;; expanded the flycheck-define-checker macro in order to eval certain args, as per advice given in gitter
-;; https://gitter.im/flycheck/flycheck?at=5a43b3a8232e79134d98872b
-(flycheck-def-executable-var solidity-checker "solc")
-(flycheck-define-command-checker 'solidity-checker
-                                 "A Solidity syntax checker using the solc compiler"
-                                 :command '("solc" source-inplace)
-                                 :error-patterns '((error line-start (file-name) ":" line ":" column ":" " Error: " (message))
-                                                   (error line-start "Error: " (message))
-                                                   (warning line-start (file-name) ":" line ":" column ":" " Warning: " (message)))
-                                 :modes 'solidity-mode
-                                 :predicate #'(lambda nil (eq major-mode 'solidity-mode))
-                                 :next-checkers `((,solidity-flycheck-chaining-error-level . solium-checker))
-                                 :standard-input 'nil
-                                 :working-directory 'nil)
-
 ;; define solium flycheck syntax checker
 (flycheck-define-checker solium-checker
                          "A Solidity linter using solium"
@@ -129,6 +112,23 @@ we pass the directory to solium via the `--config' option."
         (add-to-list 'flycheck-checkers 'solium-checker)
         (setq flycheck-solium-checker-executable solidity-solium-path))
     (error (format "Solidity Mode Configuration error. Requested solium flycheck integration but can't find solium at: %s" solidity-solium-path))))
+
+;; add a solidity mode callback to set the executable of solc for flycheck
+;; define solidity's flycheck syntax checker
+;; expanded the flycheck-define-checker macro in order to eval certain args, as per advice given in gitter
+;; https://gitter.im/flycheck/flycheck?at=5a43b3a8232e79134d98872b
+(flycheck-def-executable-var solidity-checker "solc")
+(flycheck-define-command-checker 'solidity-checker
+                                 "A Solidity syntax checker using the solc compiler"
+                                 :command '("solc" source-inplace)
+                                 :error-patterns '((error line-start (file-name) ":" line ":" column ":" " Error: " (message))
+                                                   (error line-start "Error: " (message))
+                                                   (warning line-start (file-name) ":" line ":" column ":" " Warning: " (message)))
+                                 :modes 'solidity-mode
+                                 :predicate #'(lambda nil (eq major-mode 'solidity-mode))
+                                 :next-checkers `((,solidity-flycheck-chaining-error-level . solium-checker))
+                                 :standard-input 'nil
+                                 :working-directory 'nil)
 
 (when solidity-flycheck-solc-checker-active
   (if (funcall flycheck-executable-find solidity-solc-path)

--- a/solidity-flycheck.el
+++ b/solidity-flycheck.el
@@ -84,53 +84,51 @@ we pass the directory to solium via the `--config' option."
                          :safe #'stringp
                          :package-version '(solidity-mode . "0.1.4"))
 
-;; define solium flycheck syntax checker
-(flycheck-define-checker solium-checker
-                         "A Solidity linter using solium"
-                         :command ("solium"
-                                   (option "--config=" flycheck-solidity-solium-soliumrcfile concat)
-                                   "-f"
-                                   source-inplace)
-                         :error-patterns ((error line-start (zero-or-more " ") line ":" column (zero-or-more " ") "error" (message))
-                                          (error line-start (zero-or-more not-newline) "[Fatal error]" (message))
-                                          (warning line-start (zero-or-more " ") line ":" column (zero-or-more " ") "warning" (message)))
-                         :error-filter
-                         ;; Add fake line numbers if they are missing in the lint output
-                         (lambda (errors)
-                           (dolist (err errors)
-                             (unless (flycheck-error-line err)
-                               (setf (flycheck-error-line err) 1)))
-                           errors)
-                         :modes solidity-mode
-                         :predicate (lambda () (eq major-mode 'solidity-mode)))
-
-;; first try to add solium to the checker's list since if we got solc
-;; it must come after it in the list due to it being chained after solc
 (when solidity-flycheck-solium-checker-active
+  ;; define solium flycheck syntax checker
+  (flycheck-define-checker solium-checker
+                           "A Solidity linter using solium"
+                           :command ("solium"
+                                     (option "--config=" flycheck-solidity-solium-soliumrcfile concat)
+                                     "-f"
+                                     source-inplace)
+                           :error-patterns ((error line-start (zero-or-more " ") line ":" column (zero-or-more " ") "error" (message))
+                                            (error line-start (zero-or-more not-newline) "[Fatal error]" (message))
+                                            (warning line-start (zero-or-more " ") line ":" column (zero-or-more " ") "warning" (message)))
+                           :error-filter
+                           ;; Add fake line numbers if they are missing in the lint output
+                           (lambda (errors)
+                             (dolist (err errors)
+                               (unless (flycheck-error-line err)
+                                 (setf (flycheck-error-line err) 1)))
+                             errors)
+                           :modes solidity-mode
+                           :predicate (lambda () (eq major-mode 'solidity-mode)))
+  ;; first try to add solium to the checker's list since if we got solc
+  ;; it must come after it in the list due to it being chained after solc
   (if (funcall flycheck-executable-find solidity-solium-path)
       (progn
         (add-to-list 'flycheck-checkers 'solium-checker)
         (setq flycheck-solium-checker-executable solidity-solium-path))
     (error (format "Solidity Mode Configuration error. Requested solium flycheck integration but can't find solium at: %s" solidity-solium-path))))
 
-;; add a solidity mode callback to set the executable of solc for flycheck
-;; define solidity's flycheck syntax checker
-;; expanded the flycheck-define-checker macro in order to eval certain args, as per advice given in gitter
-;; https://gitter.im/flycheck/flycheck?at=5a43b3a8232e79134d98872b
-(flycheck-def-executable-var solidity-checker "solc")
-(flycheck-define-command-checker 'solidity-checker
-                                 "A Solidity syntax checker using the solc compiler"
-                                 :command '("solc" source-inplace)
-                                 :error-patterns '((error line-start (file-name) ":" line ":" column ":" " Error: " (message))
-                                                   (error line-start "Error: " (message))
-                                                   (warning line-start (file-name) ":" line ":" column ":" " Warning: " (message)))
-                                 :modes 'solidity-mode
-                                 :predicate #'(lambda nil (eq major-mode 'solidity-mode))
-                                 :next-checkers `((,solidity-flycheck-chaining-error-level . solium-checker))
-                                 :standard-input 'nil
-                                 :working-directory 'nil)
-
 (when solidity-flycheck-solc-checker-active
+  ;; add a solidity mode callback to set the executable of solc for flycheck
+  ;; define solidity's flycheck syntax checker
+  ;; expanded the flycheck-define-checker macro in order to eval certain args, as per advice given in gitter
+  ;; https://gitter.im/flycheck/flycheck?at=5a43b3a8232e79134d98872b
+  (flycheck-def-executable-var solidity-checker "solc")
+  (flycheck-define-command-checker 'solidity-checker
+                                   "A Solidity syntax checker using the solc compiler"
+                                   :command '("solc" source-inplace)
+                                   :error-patterns '((error line-start (file-name) ":" line ":" column ":" " Error: " (message))
+                                                     (error line-start "Error: " (message))
+                                                     (warning line-start (file-name) ":" line ":" column ":" " Warning: " (message)))
+                                   :modes 'solidity-mode
+                                   :predicate #'(lambda nil (eq major-mode 'solidity-mode))
+                                   :next-checkers `((,solidity-flycheck-chaining-error-level . solium-checker))
+                                   :standard-input 'nil
+                                   :working-directory 'nil)
   (if (funcall flycheck-executable-find solidity-solc-path)
       (progn
         (add-to-list 'flycheck-checkers 'solidity-checker)

--- a/solidity-flycheck.el
+++ b/solidity-flycheck.el
@@ -74,15 +74,15 @@ Possible values are:
   :package-version '(solidity . "0.1.5"))
 
 (flycheck-def-option-var flycheck-solidity-solium-soliumrcfile nil solium-check
-			 "The path to use for soliumrc.json
+                         "The path to use for soliumrc.json
 
 The value of this variable is either a string denoting a path to the soliumrc.json
 or nil, to use the current directory.  When non-nil,
 we pass the directory to solium via the `--config' option."
-			 :type '(choice (const :tag "No custom soliumrc" nil)
-					(string :tag "Custom soliumrc file location"))
-			 :safe #'stringp
-			 :package-version '(solidity-mode . "0.1.4"))
+                         :type '(choice (const :tag "No custom soliumrc" nil)
+                                        (string :tag "Custom soliumrc file location"))
+                         :safe #'stringp
+                         :package-version '(solidity-mode . "0.1.4"))
 
 ;; add a solidity mode callback to set the executable of solc for flycheck
 ;; define solidity's flycheck syntax checker
@@ -105,60 +105,60 @@ we pass the directory to solium via the `--config' option."
 (progn
   (flycheck-def-executable-var solidity-checker "solc")
   (flycheck-define-command-checker 'solidity-checker "A Solidity syntax checker using the solc compiler" :command
-				   '("solc" source-inplace)
-				   :error-patterns
-				   '((error line-start
-					    (file-name)
-					    ":" line ":" column ":" " Error: "
-					    (message))
-				     (error line-start "Error: "
-					    (message))
-				     (warning line-start
-					      (file-name)
-					      ":" line ":" column ":" " Warning: "
-					      (message)))
-				   :modes 'solidity-mode :predicate
-				   #'(lambda nil
-				       (eq major-mode 'solidity-mode))
-				   :next-checkers
-				   `((,solidity-flycheck-chaining-error-level . solium-checker))
-				   :standard-input 'nil :working-directory 'nil))
+                                   '("solc" source-inplace)
+                                   :error-patterns
+                                   '((error line-start
+                                            (file-name)
+                                            ":" line ":" column ":" " Error: "
+                                            (message))
+                                     (error line-start "Error: "
+                                            (message))
+                                     (warning line-start
+                                              (file-name)
+                                              ":" line ":" column ":" " Warning: "
+                                              (message)))
+                                   :modes 'solidity-mode :predicate
+                                   #'(lambda nil
+                                       (eq major-mode 'solidity-mode))
+                                   :next-checkers
+                                   `((,solidity-flycheck-chaining-error-level . solium-checker))
+                                   :standard-input 'nil :working-directory 'nil))
 
 ;; define solium flycheck syntax checker
 (flycheck-define-checker solium-checker
-			 "A Solidity linter using solium"
-			 :command ("solium"
-				   (option "--config=" flycheck-solidity-solium-soliumrcfile concat)
-				   "-f"
-				   source-inplace)
-			 :error-patterns
-			 ((error line-start  (zero-or-more " ") line ":" column (zero-or-more " ") "error" (message))
-			  (error line-start (zero-or-more not-newline) "[Fatal error]" (message))
-			  (warning line-start (zero-or-more " ") line ":" column (zero-or-more " ") "warning" (message)))
-			 :error-filter
-			 ;; Add fake line numbers if they are missing in the lint output
-			 (lambda (errors)
-			   (dolist (err errors)
-			     (unless (flycheck-error-line err)
-			       (setf (flycheck-error-line err) 1)))
-			   errors)
-			 :modes solidity-mode
-			 :predicate (lambda () (eq major-mode 'solidity-mode)))
+                         "A Solidity linter using solium"
+                         :command ("solium"
+                                   (option "--config=" flycheck-solidity-solium-soliumrcfile concat)
+                                   "-f"
+                                   source-inplace)
+                         :error-patterns
+                         ((error line-start  (zero-or-more " ") line ":" column (zero-or-more " ") "error" (message))
+                          (error line-start (zero-or-more not-newline) "[Fatal error]" (message))
+                          (warning line-start (zero-or-more " ") line ":" column (zero-or-more " ") "warning" (message)))
+                         :error-filter
+                         ;; Add fake line numbers if they are missing in the lint output
+                         (lambda (errors)
+                           (dolist (err errors)
+                             (unless (flycheck-error-line err)
+                               (setf (flycheck-error-line err) 1)))
+                           errors)
+                         :modes solidity-mode
+                         :predicate (lambda () (eq major-mode 'solidity-mode)))
 
 ;; first try to add solium to the checker's list since if we got solc
 ;; it must come after it in the list due to it being chained after solc
 (when solidity-flycheck-solium-checker-active
   (if (funcall flycheck-executable-find solidity-solium-path)
       (progn
-	(add-to-list 'flycheck-checkers 'solium-checker)
-	(setq flycheck-solium-checker-executable solidity-solium-path))
+        (add-to-list 'flycheck-checkers 'solium-checker)
+        (setq flycheck-solium-checker-executable solidity-solium-path))
     (error (format "Solidity Mode Configuration error. Requested solium flycheck integration but can't find solium at: %s" solidity-solium-path))))
 
 (when solidity-flycheck-solc-checker-active
   (if (funcall flycheck-executable-find solidity-solc-path)
       (progn
-	(add-to-list 'flycheck-checkers 'solidity-checker)
-	(setq flycheck-solidity-checker-executable solidity-solc-path))
+        (add-to-list 'flycheck-checkers 'solidity-checker)
+        (setq flycheck-solidity-checker-executable solidity-solc-path))
     (error (format "Solidity Mode Configuration error. Requested solc flycheck integration but can't find solc at: %s" solidity-solc-path))))
 
 (provide 'solidity-flycheck)

--- a/solidity-flycheck.el
+++ b/solidity-flycheck.el
@@ -86,43 +86,20 @@ we pass the directory to solium via the `--config' option."
 
 ;; add a solidity mode callback to set the executable of solc for flycheck
 ;; define solidity's flycheck syntax checker
-;; (let ((next-checkers-val `((,solidity-flycheck-chaining-error-level . solium-checker))))
-;;   (flycheck-define-checker solidity-checker
-;;     "A Solidity syntax checker using the solc compiler"
-;;     :command ("solc" source-inplace)
-;;     :error-patterns
-;;     ((error line-start (file-name) ":" line ":" column ":" " Error: " (message))
-;;      (error line-start "Error: " (message))
-;;      (warning line-start (file-name) ":" line ":" column ":" " Warning: " (message)))
-;;     :next-checkers next-checkers-val
-;;     ;; :next-checkers `((,solidity-flycheck-chaining-error-level . solium-checker))
-;;     :modes solidity-mode
-;;     :predicate (lambda () (eq major-mode 'solidity-mode))))
-
-;; expanded the flycheck-define-checker macro as per advice given in gitter
-;; https://gitter.im/flycheck/flycheck?at=5a43b3a8232e79134d98872b in order to avoid the
-;; next-checkers `'` introduced by the flycheck-define-checker macro
-(progn
-  (flycheck-def-executable-var solidity-checker "solc")
-  (flycheck-define-command-checker 'solidity-checker "A Solidity syntax checker using the solc compiler" :command
-                                   '("solc" source-inplace)
-                                   :error-patterns
-                                   '((error line-start
-                                            (file-name)
-                                            ":" line ":" column ":" " Error: "
-                                            (message))
-                                     (error line-start "Error: "
-                                            (message))
-                                     (warning line-start
-                                              (file-name)
-                                              ":" line ":" column ":" " Warning: "
-                                              (message)))
-                                   :modes 'solidity-mode :predicate
-                                   #'(lambda nil
-                                       (eq major-mode 'solidity-mode))
-                                   :next-checkers
-                                   `((,solidity-flycheck-chaining-error-level . solium-checker))
-                                   :standard-input 'nil :working-directory 'nil))
+;; expanded the flycheck-define-checker macro in order to eval certain args, as per advice given in gitter
+;; https://gitter.im/flycheck/flycheck?at=5a43b3a8232e79134d98872b
+(flycheck-def-executable-var solidity-checker "solc")
+(flycheck-define-command-checker 'solidity-checker
+                                 "A Solidity syntax checker using the solc compiler"
+                                 :command '("solc" source-inplace)
+                                 :error-patterns '((error line-start (file-name) ":" line ":" column ":" " Error: " (message))
+                                                   (error line-start "Error: " (message))
+                                                   (warning line-start (file-name) ":" line ":" column ":" " Warning: " (message)))
+                                 :modes 'solidity-mode
+                                 :predicate #'(lambda nil (eq major-mode 'solidity-mode))
+                                 :next-checkers `((,solidity-flycheck-chaining-error-level . solium-checker))
+                                 :standard-input 'nil
+                                 :working-directory 'nil)
 
 ;; define solium flycheck syntax checker
 (flycheck-define-checker solium-checker
@@ -131,10 +108,9 @@ we pass the directory to solium via the `--config' option."
                                    (option "--config=" flycheck-solidity-solium-soliumrcfile concat)
                                    "-f"
                                    source-inplace)
-                         :error-patterns
-                         ((error line-start  (zero-or-more " ") line ":" column (zero-or-more " ") "error" (message))
-                          (error line-start (zero-or-more not-newline) "[Fatal error]" (message))
-                          (warning line-start (zero-or-more " ") line ":" column (zero-or-more " ") "warning" (message)))
+                         :error-patterns ((error line-start (zero-or-more " ") line ":" column (zero-or-more " ") "error" (message))
+                                          (error line-start (zero-or-more not-newline) "[Fatal error]" (message))
+                                          (warning line-start (zero-or-more " ") line ":" column (zero-or-more " ") "warning" (message)))
                          :error-filter
                          ;; Add fake line numbers if they are missing in the lint output
                          (lambda (errors)


### PR DESCRIPTION
I have labeled this "WIP" for now because it is presently only a "works for me" patch for working with my version of solium (1.1.8), and I am sure there needs to be some version-handling added to make this still handle output from older versions too, rather than only the newer one. When I find time I will try to add version-handling backward-compatibility, but that might take a while, so please add a commit of your own to do that if you don't want to wait.

Aside from updating the parsing for the new output format, I also needed to add the reporter flag because the default output reporter is now "pretty".