### PR TITLE
Avoid keyword-coloring keywords when they're substrings of tokens

### DIFF
--- a/solidity-mode.el
+++ b/solidity-mode.el
@@ -344,7 +344,7 @@ Possible values are:
 First match should be a keyword and second an identifier."
   (solidity-match-regexp
    (concat
-    " *\\(contract\\) +\\(" solidity-identifier-regexp "\\)")
+    " *\\(\\<contract\\>\\) +\\(" solidity-identifier-regexp "\\)")
    limit))
 
 (defun solidity-match-library-decl (limit)
@@ -353,7 +353,7 @@ First match should be a keyword and second an identifier."
 First match should be a keyword and second an identifier."
   (solidity-match-regexp
    (concat
-    " *\\(library\\) +\\(" solidity-identifier-regexp "\\)")
+    " *\\(\\<library\\>\\) +\\(" solidity-identifier-regexp "\\)")
    limit))
 
 (defun solidity-match-pragma-stmt (limit)
@@ -362,7 +362,7 @@ First match should be a keyword and second an identifier."
 First match should be a keyword and second an identifier."
   (solidity-match-regexp
    (concat
-    " *\\(pragma\\) +\\(.*\\);")
+    " *\\(\\<pragma\\>\\) +\\(.*\\);")
    limit))
 
 (defun solidity-match-struct-decl (limit)
@@ -371,7 +371,7 @@ First match should be a keyword and second an identifier."
 First match should be a keyword and second an identifier."
   (solidity-match-regexp
    (concat
-    " *\\(struct\\) +\\(" solidity-identifier-regexp "\\)")
+    " *\\(\\<struct\\>\\) +\\(" solidity-identifier-regexp "\\)")
    limit))
 
 (defun solidity-match-functions (limit)
@@ -380,7 +380,7 @@ First match should be a keyword and second an identifier."
 Highlight the 1st result."
   (solidity-match-regexp
    (concat
-    " *\\(function\\) +\\(" solidity-identifier-regexp "\\)")
+    " *\\(\\<function\\>\\) +\\(" solidity-identifier-regexp "\\)")
    limit))
 
 (defun solidity-match-event-decl (limit)
@@ -389,7 +389,7 @@ Highlight the 1st result."
 Highlight the 1st result."
   (solidity-match-regexp
    (concat
-    " *\\(event\\) +\\(" solidity-identifier-regexp "\\)")
+    " *\\(\\<event\\>\\) +\\(" solidity-identifier-regexp "\\)")
    limit))
 
 (defun solidity-match-modifier-decl (limit)
@@ -398,7 +398,7 @@ Highlight the 1st result."
 Highlight the 1st result."
   (solidity-match-regexp
    (concat
-    " *\\(modifier\\) +\\(" solidity-identifier-regexp "\\)")
+    " *\\(\\<modifier\\>\\) +\\(" solidity-identifier-regexp "\\)")
    limit))
 
 (defun solidity-match-mappings (limit)
@@ -407,7 +407,7 @@ Highlight the 1st result."
 Highlight the 1st result."
   (solidity-match-regexp
    (concat
-    " *\\(mapping\\) *(.*) *\\("(regexp-opt solidity-variable-modifier) " \\)*\\(" solidity-identifier-regexp "\\)")
+    " *\\(\\<mapping\\>\\) *(.*) *\\("(regexp-opt solidity-variable-modifier) " \\)*\\(" solidity-identifier-regexp "\\)")
    limit))
 
 (defun solidity-match-variable-decls (limit)
@@ -416,7 +416,7 @@ Highlight the 1st result."
 Highlight the 1st result."
   (solidity-match-regexp
    (concat
-    " *\\(" (regexp-opt solidity-builtin-types) " *\\(\\[ *[0-9]*\\]\\)* *\\) " "\\("(regexp-opt solidity-variable-modifier) " \\)* *\\(" solidity-identifier-regexp "\\)")
+    " *\\(" (regexp-opt solidity-builtin-types 'words) " *\\(\\[ *[0-9]*\\]\\)* *\\) " "\\("(regexp-opt solidity-variable-modifier 'words) " \\)* *\\(" solidity-identifier-regexp "\\)")
    limit))
 
 ;; solidity syntax table


### PR DESCRIPTION
e.g, when "struct" occurs in "constructor", don't color "struct".

This is achieved by adding word boundaries in regexps, inside the solidity-match-* functions.