### PR TITLE
Avoid running c-mode-hook.

### DIFF
--- a/solidity-mode.el
+++ b/solidity-mode.el
@@ -541,6 +541,7 @@ Cursor must be at the function's name.  Does not currently work for constructors
   (set (make-local-variable 'comment-multi-line) t)
   (set (make-local-variable 'comment-line-break-function)
        'c-indent-new-comment-line)
+  (set (make-local-variable 'c-mode-hook) nil)
 
   ;; set imenu
   (setq imenu-generic-expression

--- a/solidity-mode.el
+++ b/solidity-mode.el
@@ -63,6 +63,11 @@ Possible values are:
   :package-version '(solidity . "0.1.7")
   :safe #'symbolp)
 
+(defcustom solidity-mode-disable-c-mode-hook t
+  "If non-nil, do not run `c-mode-hook'."
+  :group 'solidity
+  :type 'boolean)
+
 (defvar solidity-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map "\C-j" 'newline-and-indent)
@@ -542,9 +547,8 @@ Cursor must be at the function's name.  Does not currently work for constructors
   (set (make-local-variable 'comment-line-break-function)
        'c-indent-new-comment-line)
 
-  ;; Do not run `c-mode-hook'.
-  ;; See https://github.com/ethereum/emacs-solidity/issues/49.
-  (set (make-local-variable 'c-mode-hook) nil)
+  (when solidity-mode-disable-c-mode-hook
+    (set (make-local-variable 'c-mode-hook) nil))
 
   ;; set imenu
   (setq imenu-generic-expression

--- a/solidity-mode.el
+++ b/solidity-mode.el
@@ -541,6 +541,9 @@ Cursor must be at the function's name.  Does not currently work for constructors
   (set (make-local-variable 'comment-multi-line) t)
   (set (make-local-variable 'comment-line-break-function)
        'c-indent-new-comment-line)
+
+  ;; Do not run `c-mode-hook'.
+  ;; See https://github.com/ethereum/emacs-solidity/issues/49.
   (set (make-local-variable 'c-mode-hook) nil)
 
   ;; set imenu


### PR DESCRIPTION
#49.
It is hard for me to switch `c-mode` with `prog-mode`.
This is workaround to avoid running `c-mode-hook` in solidity-mode.