### PR TITLE
Adjust package for solc >= 0.6.0. Also bump version to v0.1.10

### DIFF
--- a/solidity-mode.el
+++ b/solidity-mode.el
@@ -42,6 +42,7 @@
 
 (defcustom solidity-mode-hook nil
   "Callback hook to execute whenever a solidity file is loaded."
+  :type 'hook
   :group 'solidity)
 
 (defcustom solidity-comment-style 'star
@@ -500,6 +501,7 @@ Cursor must be at the function's name.  Does not currently work for constructors
 
 ;;; Support for imenu
 (defun solidity-mode-imenu-generic-expression ()
+  "Generic expressions for solidity mode imenu."
   (let* ((spacetabs "[\t\n ]+")
          (optional-spacetabs "[\t\n ]*")
          (ident-group "\\([A-Za-z_][A-Za-z0-9_]*\\)")
@@ -546,6 +548,7 @@ Cursor must be at the function's name.  Does not currently work for constructors
   (set (make-local-variable 'comment-multi-line) t)
   (set (make-local-variable 'comment-line-break-function)
        'c-indent-new-comment-line)
+
 
   (when solidity-mode-disable-c-mode-hook
     (set (make-local-variable 'c-mode-hook) nil))

--- a/solidity-mode.el
+++ b/solidity-mode.el
@@ -1,10 +1,10 @@
 ;;; solidity-mode.el --- Major mode for ethereum's solidity language
 
-;; Copyright (C) 2015-2018  Lefteris Karapetsas
+;; Copyright (C) 2015-2020  Lefteris Karapetsas
 
 ;; Author: Lefteris Karapetsas  <lefteris@refu.co>
 ;; Keywords: languages, solidity
-;; Version: 0.1.9
+;; Version: 0.1.10
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This patch makes it so that the solidity flycheck checker works
properly with solc versions >= 0.6.0

Since the output of solc >= 0.6.0 differs quite a bit from the old
versions we then utilize the `--old-reporter` argument which reverts
to the previous form of output.