### PR TITLE
Make solidity-match-variable-decls regexp's unhighlited matches shy.

### DIFF
--- a/solidity-mode.el
+++ b/solidity-mode.el
@@ -332,7 +332,7 @@ Possible values are:
    '(solidity-match-event-decl (1 font-lock-keyword-face)
                                   (2 font-lock-variable-name-face))
    '(solidity-match-variable-decls (1 font-lock-keyword-face)
-                                   (4 font-lock-variable-name-face))
+                                   (2 font-lock-variable-name-face))
    `(,(regexp-opt solidity-constants 'words) . font-lock-constant-face))
   "The font lock options for solidity.")
 
@@ -422,7 +422,7 @@ Highlight the 1st result."
 Highlight the 1st result."
   (solidity-match-regexp
    (concat
-    " *\\(" (regexp-opt solidity-builtin-types 'words) " *\\(\\[ *[0-9]*\\]\\)* *\\) " "\\("(regexp-opt solidity-variable-modifier 'words) " \\)* *\\(" solidity-identifier-regexp "\\)")
+    " *\\(" (regexp-opt solidity-builtin-types 'words) " *\\(?:\\[ *[0-9]*\\]\\)* *\\) " "\\(?:"(regexp-opt solidity-variable-modifier 'words) " \\)* *\\(" solidity-identifier-regexp "\\)")
    limit))
 
 ;; solidity syntax table


### PR DESCRIPTION
This ensures that if the two optional matches in the regexp, `\\[ *[0-9]*\\]` or
`(regexp-opt solidity-variable-modifier 'words)` have no match, the name of the
variable being declared can be still be found via the absolute match index 2.
Prior to this change, a simple `address foo` would match the regexp, but the
expected match index for the variable, 4, would have no match, which could lead
to font-lock errors in some circumstances.

[Reference for shy matches](
https://www.gnu.org/software/emacs/manual/html_node/emacs/Regexp-Backslash.html#index-shy-group_002c-in-regexp-1000)

Fixes #47