### PR TITLE
Add keyword let

### DIFF
--- a/solidity-mode.el
+++ b/solidity-mode.el
@@ -247,6 +247,7 @@ Possible values are:
     "int248"
     "int256"
 
+    "let"
     "mapping"
     "real"
     "string"


### PR DESCRIPTION
Something to think about: should "let" be under `soliidty-keywords` or `solidity-builtin-types`?

Currently, opted for the latter because I want it to be highlighted similar to `int x = 1`;