### PR TITLE
Set c-basic-offset to 4

### DIFF
--- a/solidity-mode.el
+++ b/solidity-mode.el
@@ -552,7 +552,7 @@ Cursor must be at the function's name.  Does not currently work for constructors
   (set (make-local-variable 'comment-multi-line) t)
   (set (make-local-variable 'comment-line-break-function)
        'c-indent-new-comment-line)
-
+  (set (make-local-variable 'c-basic-offset) 4)
 
   (when solidity-mode-disable-c-mode-hook
     (set (make-local-variable 'c-mode-hook) nil))


### PR DESCRIPTION
Currently  `solidity-mode` sets `c-basic-offset` to 2 by default.

[Solidity Style Guide](https://solidity.readthedocs.io/en/v0.6.8/style-guide.html#indentation) says to use 4 spaces per indentation level.