### PR TITLE
solidity-flycheck: Support project root and additional allow-paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 solidity-mode.elc
+test/elpa
+test/straight

--- a/solidity-mode.el
+++ b/solidity-mode.el
@@ -4,7 +4,7 @@
 
 ;; Author: Lefteris Karapetsas  <lefteris@refu.co>
 ;; Keywords: languages, solidity
-;; Version: 0.1.10
+;; Version: 0.1.11
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/test/solidity-flycheck-tests.el
+++ b/test/solidity-flycheck-tests.el
@@ -1,0 +1,44 @@
+;;; solidity-flycheck-tests.el --- Setup and execute all tests
+
+;;; Commentary:
+
+;; This package contains tests for the solidity-flycheck package.
+
+;;; Code:
+
+(require 'solidity-flycheck)
+
+(ert-deftest test-solidity-flycheck--solc-allow-paths ()
+  "Test that `solidity-flycheck--solc-allow-paths' contains `solidity-flycheck-solc-additional-allow-paths'."
+  (let ((solidity-flycheck-solc-additional-allow-paths '("/tmp/test1" "/tmp/test2")))
+    (should (equal
+             (solidity-flycheck--solc-allow-paths)
+             '("/tmp/test1" "/tmp/test2" ".")))))
+
+(defmacro with-temp-dirs (temp-dirs &rest body)
+  (let ((bindings (mapcar (lambda (d) `(,d (make-temp-file "" t)))
+                          temp-dirs)))
+    `(let ,bindings
+       (unwind-protect
+           (progn
+             ,@body)
+         (progn
+           (dolist (d (list ,@temp-dirs))
+             (delete-directory d t)))))))
+
+(ert-deftest test-solidity-flycheck--solc-remappings ()
+  "Test that `solidity-flycheck--solc-remappings' creates remappings for path in `solidity-flycheck--solc-allow-paths'"
+  (with-temp-dirs
+   (test-dir-1 test-dir-2 test-dir-3)
+   (let* ((default-directory test-dir-1)
+          (solidity-flycheck-solc-additional-allow-paths (list test-dir-2 test-dir-3)))
+     (make-directory (concat (file-name-as-directory test-dir-2) "subdir1"))
+     (make-directory (concat (file-name-as-directory test-dir-3) "@subdir2"))
+     (should (equal
+              (solidity-flycheck--solc-remappings)
+              (list (concat "subdir1=" (concat (file-name-as-directory test-dir-2) "subdir1"))
+                    (concat "@subdir2=" (concat (file-name-as-directory test-dir-3) "@subdir2")))))))
+  )
+
+(provide 'solidity-flycheck-tests)
+;;; solidity-flycheck-tests.el ends here

--- a/test/solidity-mode-test-setup.el
+++ b/test/solidity-mode-test-setup.el
@@ -1,0 +1,68 @@
+;;; solidity-mode-test-setup.el --- Setup and execute all tests
+
+;;; Commentary:
+
+;; This package sets up a suitable enviroment for testing
+;; solidity-mode, and executes the tests.
+;;
+;; Usage:
+;;
+;;   emacs -q -l test/solidity-mode-test-setup.el
+;;
+;; Note that this package assumes that some packages are located in
+;; specific locations.
+
+;;; Code:
+
+(setq user-init-file (or load-file-name (buffer-file-name)))
+(setq user-emacs-directory (file-name-directory user-init-file))
+
+(require 'package)
+(add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t)
+(setq package-enable-at-startup nil)
+(package-initialize)
+(when (not package-archive-contents)
+  (package-refresh-contents))
+
+(defvar bootstrap-version)
+(let ((bootstrap-file
+       (expand-file-name "straight/repos/straight.el/bootstrap.el" user-emacs-directory))
+      (bootstrap-version 5))
+  (unless (file-exists-p bootstrap-file)
+    (with-current-buffer
+        (url-retrieve-synchronously
+         "https://raw.githubusercontent.com/raxod502/straight.el/develop/install.el"
+         'silent 'inhibit-cookies)
+      (goto-char (point-max))
+      (eval-print-last-sexp)))
+  (load bootstrap-file nil 'nomessage))
+
+(straight-use-package 'use-package)
+
+(add-to-list 'load-path (expand-file-name "./"))
+(add-to-list 'load-path (expand-file-name "./test"))
+(package-install-file "solidity-mode.el")
+(package-install-file "solidity-flycheck.el")
+(global-flycheck-mode 1)
+
+(use-package solidity-mode
+  :mode ("\\.sol\\'" . solidity-mode))
+
+(use-package solidity-flycheck
+  :defer t
+  :init
+  (setq solidity-flycheck-solium-checker-active t)
+  (setq solidity-flycheck-solc-checker-active t)
+  (setq solidity-flycheck-chaining-error-level t)
+  (setq solidity-flycheck-use-project t)
+  (setq solidity-flycheck-solc-additional-allow-paths '("~/.brownie/packages"))
+  (add-hook
+   'solidity-mode-hook
+   (lambda ()
+     (require 'solidity-flycheck))))
+
+(require 'ert)
+
+(require 'solidity-flycheck-tests)
+
+(ert t)


### PR DESCRIPTION
solidity-flycheck can now detect projects.

### Project roots

When `solidity-flycheck-use-project` is t, solidity-flycheck will detect a project
and include files in the project during compilation and linting. solidity-flycheck
will look for a .soliumrc.json in a parent directory. If found, this directory is
considered the project root. If no .soliumrc.json is found, `project-roots` is used.

When `solidity-flycheck-solium-checker-active` is t, the .soliumrc.json found in
the project root will be used as the solium config, rather than a .soliumrc.json
in the same directory as the file being linted.

When `solidity-flycheck-solc-checker-active` is t, the project root will be passed
to solc using the --allow-paths flag. This means imports to other files inside the
project will lint without erorr.

### Additional allow-paths

The custom variable `solidity-flycheck-solc-additional-allow-paths` can be set to
support additional allow-paths.

This lets you import .sol files from other directories without causing linting errors.
For example, say that you use Brownie (https://github.com/eth-brownie/brownie),
which stores ethPM packages in `~/.brownie/packages` You could add `"~/.brownie/packages"` to this variable to import ethPM packages without linting errors. Subdirectories in each allow path are remapped.

Note that when `solidity-flycheck-use-project` is t, the project root will be
added to --allow-paths in addition to any paths defined here.