### PR TITLE
Ignore solc remappings that don't exist

### DIFF
--- a/solidity-flycheck.el
+++ b/solidity-flycheck.el
@@ -212,11 +212,9 @@ no .soliumrc.json is found, `project-roots' is used."
 (defun solidity-flycheck--solc-remappings ()
   (let* ((allow-paths (solidity-flycheck--solc-allow-paths)))
     (->> allow-paths
-         (mapcar
-          #'solidity-flycheck--only-subdirectories)
-
+         (remove-if-not #'file-exists-p)
+         (mapcar #'solidity-flycheck--only-subdirectories)
          -flatten
-
          (mapcar
           (lambda (dir)
             (let ((prefix (file-name-nondirectory dir)))


### PR DESCRIPTION
Only include a solc remapping if it references a path that actually exists. 

This is an enhancement from my previous PR. The motivation: I was using a global allow-path that was present on one of my machines but not the other, causing checking to fail. IMO It seems reasonable to only include remappings for paths that actually exist. 