### PR TITLE
Added support for highlighting user defined value types.

### DIFF
--- a/solidity-mode.el
+++ b/solidity-mode.el
@@ -338,6 +338,8 @@ Possible values are:
                                   (2 font-lock-variable-name-face))
    '(solidity-match-error-decl (1 font-lock-keyword-face)
                                (2 font-lock-variable-name-face))
+   '(solidity-match-user-defined-value-type-decl (1 font-lock-keyword-face)
+                               (2 font-lock-variable-name-face))
    '(solidity-match-variable-decls (1 font-lock-keyword-face)
                                    (2 font-lock-variable-name-face))
    `(,(regexp-opt solidity-constants 'words) . font-lock-constant-face))
@@ -412,6 +414,15 @@ Highlight the 1st result."
   (solidity-match-regexp
    (concat
     " *\\(\\<error\\>\\) +\\(" solidity-identifier-regexp "\\)")
+   limit))
+
+(defun solidity-match-user-defined-value-type-decl (limit)
+  "Search the buffer forward until LIMIT matching user defined value type names.
+
+Highlight the 1st result."
+  (solidity-match-regexp
+   (concat
+    " *\\(\\<type\\>\\) +\\(" solidity-identifier-regexp "\\)")
    limit))
 
 (defun solidity-match-modifier-decl (limit)


### PR DESCRIPTION
A feature from Solidity 0.8.8. (will likely release next week.)

Syntax looks like: `type MyAddress is address;`