### PR TITLE
fix indentation for the close parenthesis of function calls

### DIFF
--- a/solidity-mode.el
+++ b/solidity-mode.el
@@ -596,6 +596,10 @@ Cursor must be at the function's name.  Does not currently work for constructors
        'c-indent-new-comment-line)
   (set (make-local-variable 'c-basic-offset) 4)
 
+  ;; customize indentation more specific to Solidity
+  (make-local-variable 'c-offsets-alist)
+  (add-to-list 'c-offsets-alist '(arglist-close . c-lineup-close-paren))
+
   (when solidity-mode-disable-c-mode-hook
     (set (make-local-variable 'c-mode-hook) nil))
 


### PR DESCRIPTION
Hi,

I created a quick PR to fix the indentation of the close parenthesis in function calls.

Here is what the current indentation looks like:

```solidity
      require(
          store == msg.sender || owner() == msg.sender,
          "caller is neither store nor owner"
              );            // This parenthesis looks unaligned
```

This PR will push the close parenthesis to align with the function call:

```solidity
      require(
          cccStore == msg.sender || owner() == msg.sender,
          "caller is neither cccStore nor owner"
      );                   // Now it's aligned 
```

Can you take a look and merge if it's useful?

Thanks!