### PR TITLE
landakram's solhint revisions applied

### DIFF
--- a/solidity-common.el
+++ b/solidity-common.el
@@ -38,7 +38,7 @@
   :package-version '(solidity . "0.1.4"))
 
 (defcustom solidity-solhint-path "solhint"
-  "Path to the solium binary."
+  "Path to the solhint binary."
   :group 'solidity
   :type 'string
   :package-version '(solidity . "0.1.12"))

--- a/solidity-common.el
+++ b/solidity-common.el
@@ -37,5 +37,11 @@
   :type 'string
   :package-version '(solidity . "0.1.4"))
 
+(defcustom solidity-solhint-path "solhint"
+  "Path to the solium binary."
+  :group 'solidity
+  :type 'string
+  :package-version '(solidity . "0.1.12"))
+
 (provide 'solidity-common)
 ;;; solidity-common.el ends here

--- a/solidity-flycheck.el
+++ b/solidity-flycheck.el
@@ -260,11 +260,11 @@ no .soliumrc.json is found, `project-roots' is used."
   "A Solidity linter using solhint"
   :command `(,solidity-solhint-path "-f" "unix" source-inplace)
   :error-patterns `((error
-                     line-start (file-name) "("  line "," column "):" (zero-or-more " ")
-                     "error" (zero-or-more " ") (message))
+                     line-start (file-name) ":"  line ":" column ":" (zero-or-more " ")
+                     (zero-or-more " ") (message (one-or-more not-newline) "[Error/" (one-or-more not-newline) "]" ))
                     (warning
-                     line-start (file-name) "("  line "," column "):" (zero-or-more " ")
-                     "warning" (zero-or-more " ") (message)))
+                     line-start (file-name) ":"  line ":" column ":" (zero-or-more " ")
+                     (zero-or-more " ") (message (one-or-more not-newline) "[Warning/" (one-or-more not-newline) "]" )))
   :error-filter
   ;; Add fake line numbers if they are missing in the lint output
   #'(lambda (errors)

--- a/solidity-flycheck.el
+++ b/solidity-flycheck.el
@@ -258,7 +258,7 @@ no .soliumrc.json is found, `project-roots' is used."
 (flycheck-def-executable-var solhint-checker "solhint")
 (flycheck-define-command-checker 'solhint-checker
   "A Solidity linter using solhint"
-  :command `(,solidity-solhint-path "-f" "visualstudio" source-inplace)
+  :command `(,solidity-solhint-path "-f" "unix" source-inplace)
   :error-patterns `((error
                      line-start (file-name) "("  line "," column "):" (zero-or-more " ")
                      "error" (zero-or-more " ") (message))


### PR DESCRIPTION
Ethlint (formerly Solium) package has a bug about the call function. So I decide to use solhint. 
I just merged [landakram's solhint implementation](https://github.com/landakram/emacs-solidity/tree/solhint) to master branch and correct some typos from [here](https://github.com/ethereum/emacs-solidity/pull/75#discussion_r726671178) and [here](https://github.com/ethereum/emacs-solidity/pull/75#discussion_r726678588).

With this implementation solc can work with both linters or only selected one.
